### PR TITLE
Add GitHub Actions workflow for NuGet publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ permissions:
   contents: write
 
 on:
-  push:
-    branches: [ master ]
-    paths: [ 'src/ProjectToFileBasedAppConverter/**' ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Introduces publish.yml to automate building, versioning, and publishing the ProjectToFileBasedAppConverter .NET project to NuGet on master branch updates or manual triggers. Also creates a GitHub release for each published version.