### PR TITLE
Update workflow name in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish ProjectToFileBasedAppConverter on NuGet
+name: Publish on NuGet
 
 permissions:
   contents: write


### PR DESCRIPTION
Renamed the workflow from "Publish ProjectToFileBasedAppConverter on NuGet" to "Publish on NuGet" for brevity and clarity. No functional changes were made.